### PR TITLE
Fix error when calling nb.Predict()

### DIFF
--- a/Chapter05/naive_bayes/example1/myprogram.go
+++ b/Chapter05/naive_bayes/example1/myprogram.go
@@ -31,7 +31,10 @@ func main() {
 	}
 
 	// Make our predictions.
-	predictions := nb.Predict(convertToBinary(testData))
+	predictions, err := nb.Predict(convertToBinary(testData))
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	// Generate a Confusion Matrix.
 	cm, err := evaluation.GetConfusionMatrix(testData, predictions)


### PR DESCRIPTION
nb.Predict retruns two variables, the other being error. This example won't compile if error is not handled.