### PR TITLE
Fix error in silhouette calculation

### DIFF
--- a/Chapter06/evaluating/example2/myprogram.go
+++ b/Chapter06/evaluating/example2/myprogram.go
@@ -135,8 +135,9 @@ func main() {
 		// Add to the average silhouette coefficient.
 		if a > b {
 			silhouette += ((b - a) / a) / float64(len(labels))
+		} else {
+			silhouette += ((b - a) / b) / float64(len(labels))
 		}
-		silhouette += ((b - a) / b) / float64(len(labels))
 	}
 
 	// Output the final average silhouette coeffcient to stdout.


### PR DESCRIPTION
According to the book, it's (b-a)/max(a, b), but without else statement it would be added twice when a > b

This also slightly changes the resulting value for this example, but not much (0.508 becomes 0.517)